### PR TITLE
Avoid custom JVPs, some drive-by problem fixes for compatibility with recent JAX

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This is for you if you write optimisation software in JAX (or Python) and want t
 ```bash
 pip install sif2jax
 ```
-Requires Python 3.11+.
+Requires Python 3.11+ and JAX 0.7.2+.
 
 ## Getting started
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
   "Topic :: Scientific/Engineering :: Mathematics"
 ]
 dependencies = [
-  "jax>=0.4.38",
+  "jax>=0.7.2",
   "jaxtyping>=0.2.20",
   "typing_extensions>=4.5.0",
   "wadler_lindig>=0.1.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ name = "sif2jax"
 readme = "README.md"
 requires-python = ">=3.10"
 urls = {repository = "https://github.com/johannahaffner/sif2jax"}
-version = "0.0.7"
+version = "0.0.8"
 
 [project.optional-dependencies]
 docs = [

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -3,7 +3,7 @@
 # Configuration
 CONTAINER_IMAGE="johannahaffner/pycutest:latest"
 MOUNT_PATH="/workspace"
-LOCAL_PATH="/Users/jhaffner/Desktop/projects/benchmarks/ordering-fixes"
+LOCAL_PATH="/Users/jhaffner/Desktop/projects/benchmarks/sif2jax"
 
 # Run tests in container
 docker run --rm \

--- a/sif2jax/_misc.py
+++ b/sif2jax/_misc.py
@@ -7,25 +7,10 @@ Source: https://github.com/patrick-kidger/optimistix/blob/9927984fb8cbec77f9514f
 import jax.numpy as jnp
 
 
-def _asarray(dtype, x):
-    return jnp.asarray(x, dtype=dtype)
-
-
-# Work around JAX issue #15676
-# _asarray = jax.custom_jvp(_asarray, nondiff_argnums=(0,))
-
-
-# @_asarray.defjvp
-# def _asarray_jvp(dtype, x, tx):
-#    (x,) = x
-#    (tx,) = tx
-#    return _asarray(dtype, x), _asarray(dtype, tx)
-
-
 def asarray(x):
     """Convert x to array with appropriate dtype."""
     dtype = jnp.result_type(x)
-    return _asarray(dtype, x)
+    return jnp.asarray(x, dtype=dtype)
 
 
 def inexact_asarray(x):
@@ -33,4 +18,4 @@ def inexact_asarray(x):
     dtype = jnp.result_type(x)
     if not jnp.issubdtype(jnp.result_type(x), jnp.inexact):
         dtype = jnp.float64
-    return _asarray(dtype, x)
+    return jnp.asarray(x, dtype=dtype)

--- a/sif2jax/_misc.py
+++ b/sif2jax/_misc.py
@@ -4,7 +4,6 @@ This module contains utilities copied from the Optimistix library.
 Source: https://github.com/patrick-kidger/optimistix/blob/9927984fb8cbec77f9514fad7af076dce64e3993/optimistix/_misc.py#L144
 """
 
-import jax
 import jax.numpy as jnp
 
 
@@ -13,14 +12,14 @@ def _asarray(dtype, x):
 
 
 # Work around JAX issue #15676
-_asarray = jax.custom_jvp(_asarray, nondiff_argnums=(0,))
+# _asarray = jax.custom_jvp(_asarray, nondiff_argnums=(0,))
 
 
-@_asarray.defjvp
-def _asarray_jvp(dtype, x, tx):
-    (x,) = x
-    (tx,) = tx
-    return _asarray(dtype, x), _asarray(dtype, tx)
+# @_asarray.defjvp
+# def _asarray_jvp(dtype, x, tx):
+#    (x,) = x
+#    (tx,) = tx
+#    return _asarray(dtype, x), _asarray(dtype, tx)
 
 
 def asarray(x):

--- a/sif2jax/cutest/_bounded_minimisation/explin2.py
+++ b/sif2jax/cutest/_bounded_minimisation/explin2.py
@@ -61,11 +61,11 @@ class EXPLIN2(AbstractBoundedMinimisation):
         linear_part = jnp.dot(coefficients, y)
 
         # Exponential part: sum_{i=1}^M exp(0.1 * (i/M) * x_i * x_{i+1})
-        # Each term has a scaling factor P = i/M
-        exp_part = 0.0
-        for i in range(self.M):
-            p = (i + 1) / self.M  # i/M where i goes from 1 to M
-            exp_part += jnp.exp(0.1 * p * y[i] * y[i + 1])
+        # Vectorized computation over all M terms
+        i_vals = jnp.arange(1, self.M + 1, dtype=y.dtype)
+        p_vals = i_vals / self.M
+        exp_terms = jnp.exp(0.1 * p_vals * y[: self.M] * y[1 : self.M + 1])
+        exp_part = jnp.sum(exp_terms)
 
         return linear_part + exp_part
 

--- a/sif2jax/cutest/_constrained_minimisation/liswet_base.py
+++ b/sif2jax/cutest/_constrained_minimisation/liswet_base.py
@@ -25,16 +25,16 @@ class _AbstractLISWET(AbstractConstrainedMinimisation):
     Classification: QLR2-AN-V-V
     """
 
-    # Pre-computed values as tuples (hashable for Equinox)
-    _perturbation: tuple
-    _t_values: tuple
-    _constraint_coeffs: tuple
-
     n: int = 2000
     k: int = 2
 
     y0_iD: int = 0
     provided_y0s: frozenset = frozenset({0})
+
+    # Pre-computed values as tuples (hashable for Equinox)
+    _perturbation: tuple = ()
+    _t_values: tuple = ()
+    _constraint_coeffs: tuple = ()
 
     def __init__(self, n: int = 2000, k: int = 2):
         """Initialize with pre-computed values for performance."""

--- a/sif2jax/cutest/_quadratic_problems/cvxbqp1.py
+++ b/sif2jax/cutest/_quadratic_problems/cvxbqp1.py
@@ -21,7 +21,7 @@ class CVXBQP1(AbstractBoundedQuadraticProblem):
     @property
     def n(self):
         """Number of variables."""
-        return 10000  # Default size from SIF file
+        return 100000  # Default size from SIF file
 
     def objective(self, y, args):
         """Compute the objective."""

--- a/sif2jax/cutest/_quadratic_problems/cvxqp1.py
+++ b/sif2jax/cutest/_quadratic_problems/cvxqp1.py
@@ -21,7 +21,7 @@ class CVXQP1(AbstractConstrainedQuadraticProblem):
     @property
     def n(self):
         """Number of variables."""
-        return 100  # Default size
+        return 10000  # Default size
 
     @property
     def m(self):

--- a/sif2jax/cutest/_quadratic_problems/hs88.py
+++ b/sif2jax/cutest/_quadratic_problems/hs88.py
@@ -40,10 +40,7 @@ class HS88(AbstractConstrainedQuadraticProblem):
     def objective(self, y, args):
         """Quadratic objective function."""
         del args
-        x1, x2 = y[0], y[1]
-
-        # Simple quadratic objective: x1^2 + x2^2
-        return x1**2 + x2**2
+        return jnp.sum(y**2)
 
     @property
     def bounds(self):

--- a/sif2jax/cutest/_quadratic_problems/hs89.py
+++ b/sif2jax/cutest/_quadratic_problems/hs89.py
@@ -40,10 +40,7 @@ class HS89(AbstractConstrainedQuadraticProblem):
     def objective(self, y, args):
         """Quadratic objective function."""
         del args
-        x1, x2, x3 = y[0], y[1], y[2]
-
-        # Simple quadratic objective: x1^2 + x2^2 + x3^2
-        return x1**2 + x2**2 + x3**2
+        return jnp.sum(y**2)
 
     @property
     def bounds(self):

--- a/sif2jax/cutest/_quadratic_problems/hs90.py
+++ b/sif2jax/cutest/_quadratic_problems/hs90.py
@@ -40,10 +40,7 @@ class HS90(AbstractConstrainedQuadraticProblem):
     def objective(self, y, args):
         """Quadratic objective function."""
         del args
-        x1, x2, x3, x4 = y[0], y[1], y[2], y[3]
-
-        # Simple quadratic objective: sum of squares
-        return x1**2 + x2**2 + x3**2 + x4**2
+        return jnp.sum(y**2)
 
     @property
     def bounds(self):

--- a/sif2jax/cutest/_unconstrained_minimisation/dixmaana1.py
+++ b/sif2jax/cutest/_unconstrained_minimisation/dixmaana1.py
@@ -28,7 +28,7 @@ class DIXMAANA1(AbstractUnconstrainedMinimisation):
     y0_iD: int = 0
     provided_y0s: frozenset = frozenset({0})
 
-    n: int = 3000  # Default dimension
+    n: int = 3  # Default dimension (M=1, N=3*M=3)
 
     def objective(self, y, args):
         del args
@@ -81,5 +81,5 @@ class DIXMAANA1(AbstractUnconstrainedMinimisation):
 
     @property
     def expected_objective_value(self):
-        # At the origin, all terms are zero
-        return jnp.array(0.0)
+        # At the origin, all terms are zero except the constant of 1.0
+        return jnp.array(1.0)


### PR DESCRIPTION
We had one custom JVP here - this was due to a workaround for jnp.asarray relevant in JAX versions prior to 0.7.2. I've retired this and increased our minimum supported JAX version to 0.7.2, since custom JVPs do not support sparsity detection (they are basically black boxes for this purpose) and that is an important use case in other projects we are working on. 

While upgrading the JAX version and re-building the Docker container for `johannahaffner/pycutest:latest`, a few drive-by changes were necessary: 

- three problems seem to now be registered upstream with different problem dimensions, those were altered to match the current CUTEst configuration
- other problems showed runtime pessimisations on the newer JAX version and were refactored to avoid these.