### PR TITLE
fix: avoid timing array creation

### DIFF
--- a/benchmarks/run_benchmarks.sh
+++ b/benchmarks/run_benchmarks.sh
@@ -3,7 +3,7 @@
 # Configuration
 CONTAINER_IMAGE="johannahaffner/pycutest:latest"
 MOUNT_PATH="/workspace"  # Path inside container where your code will be mounted
-LOCAL_PATH=/Users/jhaffner/Desktop/sif2jax  # For docker-in-docker setup
+LOCAL_PATH="$(cd "$(dirname "$0")/.." && pwd)"
 
 # Run benchmarks in container
 docker run --rm \

--- a/benchmarks/test_runtime_benchmark.py
+++ b/benchmarks/test_runtime_benchmark.py
@@ -29,7 +29,7 @@ def test_sif2jax_objective_benchmark(benchmark, problem):
         return compiled_objective(y0, args).block_until_ready()
 
     # Run benchmark
-    benchmark(jax_obj, problem.y0, problem.args)
+    benchmark(jax_obj, jax.device_put(problem.y0), jax.device_put(problem.args))
 
     # Store extra info for reporting
     benchmark.extra_info.update(

--- a/benchmarks/test_runtime_benchmark.py
+++ b/benchmarks/test_runtime_benchmark.py
@@ -1,4 +1,5 @@
 import jax
+import numpy as np
 import pycutest  # pyright: ignore[reportMissingImports]
 import pytest
 import sif2jax
@@ -24,11 +25,11 @@ def test_sif2jax_objective_benchmark(benchmark, problem):
     _ = compiled_objective(problem.y0, problem.args).block_until_ready()
 
     # Define function to benchmark
-    def jax_obj():
-        return compiled_objective(problem.y0, problem.args).block_until_ready()
+    def jax_obj(y0, args):
+        return compiled_objective(y0, args).block_until_ready()
 
     # Run benchmark
-    benchmark(jax_obj)
+    benchmark(jax_obj, problem.y0, problem.args)
 
     # Store extra info for reporting
     benchmark.extra_info.update(
@@ -61,14 +62,14 @@ def test_pycutest_objective_benchmark(benchmark, problem):
         pytest.skip(f"Could not load pycutest problem {problem.name}: {e}")
 
     # Warm up
-    _ = pycutest_problem.obj(problem.y0)
+    _ = pycutest_problem.obj(np.asarray(problem.y0))
 
     # Define function to benchmark
-    def pycutest_obj():
-        return pycutest_problem.obj(problem.y0)
+    def pycutest_obj(y0):
+        return pycutest_problem.obj(y0)
 
     # Run benchmark
-    benchmark(pycutest_obj)
+    benchmark(pycutest_obj, np.asarray(problem.y0))
 
     # Store extra info for reporting
     benchmark.extra_info.update(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ keywords = ["jax"]
 license = {file = "LICENSE"}
 name = "sif2jax"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 urls = {repository = "https://github.com/johannahaffner/sif2jax"}
 version = "0.0.8"
 

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -3,7 +3,7 @@
 # Configuration
 CONTAINER_IMAGE="johannahaffner/pycutest:latest"
 MOUNT_PATH="/workspace"
-LOCAL_PATH="/Users/jhaffner/Desktop/projects/benchmarks/sif2jax"
+LOCAL_PATH="$(cd "$(dirname "$0")" && pwd)"
 
 # Run tests in container
 docker run --rm \


### PR DESCRIPTION
Hi Johanna, I had a go at benchmarking my second order solvers on sif2jax problems but some had prohibitively expensive hessian calculations, I've managed to improve this but realised I needed to lay some foundations first so we can track the changes.

This is a simple cleanup PR:

1. Previously timings included array creation and for large dimensions but cheap function this would be >90% of the measured runtime. Pre-creating the array using pytest-benchmark avoids this.
2. pycutest benchmarks seemed to fail with error `Exception: Argument 1 must be a 1D double array of length nvar.` when trying to call `self.free_to_all` on a Jax array—converting to a numpy array before benchmarking seems to fix this
3. The benchmark scripts wouldn't run on my machine as they had hardcoded paths, I made these more agnostic so they can be run in other setups.
4. The project wouldn't run with uv because there is no version of jax>=0.7.2 that runs with python 3.10, even if I want to run with a higher version of uv, uv just errors on this. Bumping the lower bound of Python to 3.11 fixes this.