### PR TITLE
remove triu/eye constants from CHARDIS0, HADAMALS, EIGEN objectives

### DIFF
--- a/sif2jax/cutest/__init__.py
+++ b/sif2jax/cutest/__init__.py
@@ -8,7 +8,7 @@ from ._bounded_minimisation import (
     BRANIN as BRANIN,
     CAMEL6 as CAMEL6,
     CHARDIS0 as CHARDIS0,
-    # CHARDIS02 as CHARDIS02,  # TODO: Human review needed
+    # CHARDIS02 as CHARDIS02,  # TODO: gradient ill-conditioned at y0
     # CLPLATEA as CLPLATEA,
     # CLPLATEB as CLPLATEB,
     # CLPLATEC as CLPLATEC,
@@ -163,8 +163,8 @@ from ._constrained_minimisation import (
     CB3 as CB3,
     CHACONN1 as CHACONN1,
     CHACONN2 as CHACONN2,
-    # CHARDIS1 as CHARDIS1,  # TODO: Human review needed
-    # CHARDIS12 as CHARDIS12,  # TODO: Human review needed
+    # CHARDIS1 as CHARDIS1,  # TODO: starting value mismatch
+    # CHARDIS12 as CHARDIS12,  # TODO: starting value + gradient ill-conditioned
     CLEUVEN2 as CLEUVEN2,
     CLEUVEN3 as CLEUVEN3,
     CLEUVEN4 as CLEUVEN4,
@@ -1222,8 +1222,8 @@ problems_dict = {
     "CB3": CB3(),
     "CHACONN1": CHACONN1(),
     "CHACONN2": CHACONN2(),
-    # "CHARDIS1": CHARDIS1(),  # TODO: Human review needed
-    # "CHARDIS12": CHARDIS12(),  # TODO: Human review needed
+    # "CHARDIS1": CHARDIS1(),  # TODO: starting value mismatch
+    # "CHARDIS12": CHARDIS12(),  # TODO: starting value + gradient ill-conditioned
     "CLEUVEN2": CLEUVEN2(),
     "CLEUVEN3": CLEUVEN3(),
     "CLEUVEN4": CLEUVEN4(),
@@ -1594,7 +1594,7 @@ problems_dict = {
     # "BRKMCC": BRKMCC(),  # TODO: Human review - significant discrepancies
     "CAMEL6": CAMEL6(),
     "CHARDIS0": CHARDIS0(),
-    # "CHARDIS02": CHARDIS02(),  # TODO: Human review needed
+    # "CHARDIS02": CHARDIS02(),  # TODO: gradient ill-conditioned at y0
     # "CLPLATEA": CLPLATEA(),
     # "CLPLATEB": CLPLATEB(),
     # "CLPLATEC": CLPLATEC(),

--- a/sif2jax/cutest/_bounded_minimisation/__init__.py
+++ b/sif2jax/cutest/_bounded_minimisation/__init__.py
@@ -7,7 +7,7 @@ from .branin import BRANIN as BRANIN
 from .camel6 import CAMEL6 as CAMEL6
 from .chardis0 import CHARDIS0 as CHARDIS0
 
-# from .chardis02 import CHARDIS02 as CHARDIS02  # TODO: Human review needed
+# from .chardis02 import CHARDIS02 as CHARDIS02  # TODO: gradient ill-conditioned at y0
 # from .clplatea import CLPLATEA as CLPLATEA
 # from .clplateb import CLPLATEB as CLPLATEB
 # from .clplatec import CLPLATEC as CLPLATEC
@@ -174,7 +174,7 @@ bounded_minimisation_problems = (
     BRANIN(),
     CAMEL6(),
     CHARDIS0(),
-    # CHARDIS02(),  # TODO: Human review needed
+    # CHARDIS02(),  # TODO: gradient ill-conditioned at y0
     # CLPLATEA(),
     # CLPLATEB(),
     # CLPLATEC(),

--- a/sif2jax/cutest/_bounded_minimisation/chardis0.py
+++ b/sif2jax/cutest/_bounded_minimisation/chardis0.py
@@ -82,33 +82,18 @@ class CHARDIS0(AbstractBoundedMinimisation):
         The objective is the sum of reciprocals of squared distances.
         This is the "incorrectly decoded" version - we match pycutest's interpretation.
         """
-        n_charges = self.n_charges
         # Extract coordinates from interleaved format [x1,y1,x2,y2,...]
-        x = y[::2]  # x coordinates at even indices
-        y_coords = y[1::2]  # y coordinates at odd indices
+        x = y[::2]
+        y_coords = y[1::2]
 
-        # Compute pairwise squared distances
-        # Use broadcasting for vectorization
-        xi = x[:, None]
-        xj = x[None, :]
-        yi = y_coords[:, None]
-        yj = y_coords[None, :]
-
-        dx = xi - xj
-        dy = yi - yj
+        # Pairwise differences via subtract.outer (symmetric, so sum all and halve)
+        dx = jnp.subtract.outer(x, x)
+        dy = jnp.subtract.outer(y_coords, y_coords)
         dist_sq = dx**2 + dy**2
 
-        # Mask to get upper triangular (i < j)
-        mask = jnp.triu(jnp.ones((n_charges, n_charges)), k=1)
-
-        # CHARDIS0: Linear function (incorrectly decoded)
-        # SIF has no "XT O(I,J) REZIP" line, so uses default linear function
-        # SIF has "XN O(I,J) 'SCALE' 0.01"
-        # In CUTEst, we divide by the scaling factor: obj / 0.01 = obj * 100
-        masked_dist_sq = mask * dist_sq
-
-        # Divide by scaling factor 0.01 (multiply by 100)
-        return jnp.sum(masked_dist_sq) / 0.01
+        # Full sum = 2x upper-triangular; diagonal is zero, no correction
+        # SIF scaling: divide by 0.01
+        return 0.5 * jnp.sum(dist_sq) / 0.01
 
     @property
     def expected_result(self):

--- a/sif2jax/cutest/_bounded_minimisation/chardis02.py
+++ b/sif2jax/cutest/_bounded_minimisation/chardis02.py
@@ -6,11 +6,11 @@ from ..._problem import AbstractBoundedMinimisation
 class CHARDIS02(AbstractBoundedMinimisation):
     """Distribution of equal charges on [-R,R]x[-R,R] (2D).
 
-    Minimize the scaled sum of reciprocals of distances between charges.
-    This is the corrected version of CHARDIS0.
+    Minimize the scaled sum of reciprocals of squared distances between charges.
+    This is the corrected version of CHARDIS0 (uses REZIP group function).
 
     Problem:
-    min 0.01 * sum_{i=1}^{n-1} sum_{j=i+1}^{n} 1/sqrt[(x_i - x_j)^2 + (y_i - y_j)^2]
+    min sum_{i=1}^{n-1} sum_{j=i+1}^{n} 1/[(x_i - x_j)^2 + (y_i - y_j)^2] / 0.01
 
     Subject to:
     -R <= x_i <= R for all i
@@ -25,14 +25,10 @@ class CHARDIS02(AbstractBoundedMinimisation):
 
     classification: OBR2-AY-V-V
 
-    TODO: Human review needed
-    Attempts made: [SIF analysis, REZIP function implementation, scaling
-    interpretation, empirical scaling]
-    Suspected issues: Complex scaling interaction between REZIP function
-    and 0.01 scaling factor
-    Resources needed: Mathematical analysis of REZIP scaling in pycutest
-    vs SIF implementation
-    Error: Objective differs by factor ~1.87, gradient proportionally different
+    TODO: Gradient at y0 fails np.allclose with default rtol=1e-5.
+    The 1/dist_sq formulation is ill-conditioned for close charges
+    (dist_sq ~ 5e-4 at y0). Gradient is correct within rtol=1e-2.
+    All other gradient tests (zeros, ones, alternating) pass.
     """
 
     y0_iD: int = 0
@@ -81,42 +77,28 @@ class CHARDIS02(AbstractBoundedMinimisation):
     def objective(self, y, args):
         """Compute the objective function.
 
-        The objective is the sum of reciprocals of distances (not squared distances).
-        This is the corrected formulation.
+        REZIP group function: F = 1/ALPHA where ALPHA = (xi-xj)^2 + (yi-yj)^2
+        This is 1/dist_sq (reciprocal of SQUARED distance), not 1/dist.
+        Each group has SCALE 0.01, so CUTEst divides by 0.01.
         """
         n_charges = self.n_charges
         # Extract coordinates from interleaved format [x1,y1,x2,y2,...]
-        x = y[::2]  # x coordinates at even indices
-        y_coords = y[1::2]  # y coordinates at odd indices
+        x = y[::2]
+        y_coords = y[1::2]
 
-        # Compute pairwise squared distances
-        # Use broadcasting for vectorization
-        xi = x[:, None]
-        xj = x[None, :]
-        yi = y_coords[:, None]
-        yj = y_coords[None, :]
-
-        dx = xi - xj
-        dy = yi - yj
+        # Pairwise differences via subtract.outer
+        dx = jnp.subtract.outer(x, x)
+        dy = jnp.subtract.outer(y_coords, y_coords)
         dist_sq = dx**2 + dy**2
 
-        # Mask to get upper triangular (i < j)
-        mask = jnp.triu(jnp.ones((n_charges, n_charges)), k=1)
+        # Add identity to diagonal so 1/(0+1)=1 on diagonal (avoids 1/0),
+        # then subtract n_charges/2 to correct for diagonal after halving
+        dist_sq_safe = dist_sq + jnp.eye(n_charges)
+        reciprocals = 1.0 / dist_sq_safe
 
-        # CHARDIS02: REZIP function (corrected version of CHARDIS0)
-        # SIF has "XT O(I,J) REZIP" line, so uses REZIP function F = 1.0/ALPHA
-        # SIF has "XN O(I,J) 'SCALE' 0.01" scaling factor
-        # where ALPHA = sqrt(X(I,J) + Y(I,J)) = sqrt((xi-xj)^2 + (yi-yj)^2)
-        # In CUTEst, we divide by the scaling factor: obj / 0.01 = obj * 100
-
-        eps = 1e-8
-        dist = jnp.sqrt(dist_sq + eps)
-        reciprocals = mask / dist
-
-        # Divide by scaling factor 0.01 (multiply by 100)
-        # Note: The empirical factor of ~2727 suggests additional scaling in pycutest
-        # We use the empirical value to match pycutest's implementation
-        return 2727.0 * jnp.sum(reciprocals)
+        # Symmetric: sum all and halve, minus diagonal contribution (n * 1.0 / 2)
+        # SIF scaling: divide by 0.01
+        return (0.5 * jnp.sum(reciprocals) - 0.5 * n_charges) / 0.01
 
     @property
     def expected_result(self):

--- a/sif2jax/cutest/_bounded_minimisation/hadamals.py
+++ b/sif2jax/cutest/_bounded_minimisation/hadamals.py
@@ -46,29 +46,24 @@ class HADAMALS(AbstractBoundedMinimisation):
         2. S(I,J): Entry constraints with LARGEL2 group type (scaled L2)
         """
         n = self.n
-        rn = float(n)  # RN in SIF is N, not sqrt(N)
 
         # Reshape flat vector to matrix (column-major for SIF compatibility)
         Q = y.reshape((n, n), order="F")
 
-        # Compute orthogonality terms:
-        # sum over (i,j) with i<=j of (QtQ[i,j] - RN*delta[i,j])^2
-        QtQ = jnp.dot(Q.T, Q)
-
-        # O(I,J) groups: orthogonality constraints
-        # (QtQ[i,j] - RN*delta[i,j])^2 for upper triangle (i <= j)
-        target = rn * jnp.eye(n, dtype=y.dtype)
-        diff = QtQ - target
-
-        # Upper triangle only (including diagonal)
-        obj = jnp.sum(jnp.triu(diff) ** 2)
+        # Q^T @ Q orthogonality: want Q^T Q = n*I
+        # sum_{i<=j} (QtQ[i,j] - n*delta_{ij})^2
+        # Correct diagonal so 0.5*sum(M^2) = triu_sum:
+        # need M[i,i] = sqrt(2)*(d[i]-n) so 0.5*M[i,i]^2 = (d[i]-n)^2
+        QtQ = Q.T @ Q
+        d = jnp.diagonal(QtQ)
+        diag_correction = (jnp.sqrt(2.0) - 1.0) * d - jnp.sqrt(2.0) * n
+        corrected = QtQ + jnp.diag(diag_correction)
+        obj = 0.5 * jnp.sum(corrected**2)
 
         # S(I,J) groups: entry constraints (Q[i,j]^2 - 1)^2 for i>=2
-        # Using LARGEL2 group type with FACTOR=1.0
-        # Vectorized: slice rows i=1 to n-1 (0-indexed)
-        Q_slice = Q[1:, :]  # All rows except first, all columns
-        entry_vals = Q_slice * Q_slice - 1.0
-        obj = obj + jnp.sum(entry_vals * entry_vals)
+        Q_slice = Q[1:, :]
+        entry_vals = Q_slice**2 - 1.0
+        obj = obj + jnp.sum(entry_vals**2)
 
         return jnp.array(obj)
 

--- a/sif2jax/cutest/_constrained_minimisation/__init__.py
+++ b/sif2jax/cutest/_constrained_minimisation/__init__.py
@@ -56,8 +56,8 @@ from .cb3 import CB3 as CB3
 from .chaconn1 import CHACONN1 as CHACONN1
 from .chaconn2 import CHACONN2 as CHACONN2
 
-# from .chardis1 import CHARDIS1 as CHARDIS1  # TODO: Human review needed
-# from .chardis12 import CHARDIS12 as CHARDIS12  # TODO: Human review needed
+# from .chardis1 import CHARDIS1 as CHARDIS1  # TODO: starting value mismatch
+# from .chardis12 import CHARDIS12 as CHARDIS12  # TODO: y0 + gradient
 # from .cresc4 import CRESC4 as CRESC4  # TODO: Human review - complex crescent area
 # TODO: CLNLBEAM needs fixing - dimension mismatch in constraints
 # from .clnlbeam import CLNLBEAM as CLNLBEAM
@@ -588,8 +588,8 @@ constrained_minimisation_problems = (
     CB3(),
     CHACONN1(),
     CHACONN2(),
-    # CHARDIS1(),  # TODO: Human review needed
-    # CHARDIS12(),  # TODO: Human review needed
+    # CHARDIS1(),  # TODO: starting value mismatch
+    # CHARDIS12(),  # TODO: starting value + gradient ill-conditioned
     # CLNLBEAM(),  # TODO: Dimension mismatch in constraints
     CLEUVEN2(),
     CLEUVEN3(),

--- a/sif2jax/cutest/_constrained_minimisation/chardis1.py
+++ b/sif2jax/cutest/_constrained_minimisation/chardis1.py
@@ -25,14 +25,6 @@ class CHARDIS1(AbstractConstrainedMinimisation):
 
     classification: OQR2-AY-V-V
 
-    TODO: Human review needed
-    Attempts made: [SIF analysis, starting value correction, constraint
-    implementation, linear vs REZIP analysis]
-    Suspected issues: Starting value precision, constraint formulation
-    vs pycutest implementation
-    Resources needed: Detailed comparison of SIF starting value computation
-    vs pycutest
-    Error: First constraint differs by 0.002, affecting all other computations
     """
 
     y0_iD: int = 0
@@ -109,30 +101,17 @@ class CHARDIS1(AbstractConstrainedMinimisation):
         where X(I,J), Y(I,J) are squared differences (xi-xj)^2, (yi-yj)^2
         No scaling factor in CHARDIS1 SIF.
         """
-        n_charges = self.n_charges
         # Extract coordinates from interleaved format [x1,y1,x2,y2,...]
-        x = y[::2]  # x coordinates at even indices
-        y_coords = y[1::2]  # y coordinates at odd indices
+        x = y[::2]
+        y_coords = y[1::2]
 
-        # Compute pairwise squared distances
-        # Use broadcasting for vectorization
-        xi = x[:, None]
-        xj = x[None, :]
-        yi = y_coords[:, None]
-        yj = y_coords[None, :]
-
-        dx = xi - xj
-        dy = yi - yj
+        # Pairwise differences via subtract.outer (symmetric, so sum all and halve)
+        dx = jnp.subtract.outer(x, x)
+        dy = jnp.subtract.outer(y_coords, y_coords)
         dist_sq = dx**2 + dy**2
 
-        # Mask to get upper triangular (i < j)
-        mask = jnp.triu(jnp.ones((n_charges, n_charges)), k=1)
-
-        # CHARDIS1: sum of squared distances (not reciprocals)
-        # This is X(I,J) + Y(I,J) = (xi-xj)^2 + (yi-yj)^2
-        masked_dist_sq = mask * dist_sq
-
-        return jnp.sum(masked_dist_sq)
+        # Full sum is 2x the upper-triangular sum; diagonal is zero so no correction
+        return 0.5 * jnp.sum(dist_sq)
 
     @property
     def expected_result(self):
@@ -164,16 +143,19 @@ class CHARDIS1(AbstractConstrainedMinimisation):
         return lower, upper
 
     def constraint(self, y):
-        """Circle constraints: x_i^2 + y_i^2 = R^2 for i = 2, ..., n as inequalities."""
-        r = 1.0  # R = 1.0 for CHARDIS1 (from SIF file)
-        r2 = r * r
+        """Inequality constraints: x_i^2 + y_i^2 >= R^2 for i = 2, ..., n.
+
+        SIF uses XL RES(I) with constant R^2, meaning RES(I) >= R^2,
+        i.e. x_i^2 + y_i^2 >= R^2 (charges on or outside the circle).
+        Convention: return c(y) where c(y) >= 0.
+        """
+        r2 = 1.0  # R^2 = 1.0 for CHARDIS1
 
         # Extract coordinates from interleaved format [x1,y1,x2,y2,...]
-        x = y[::2]  # x coordinates at even indices
-        y_coords = y[1::2]  # y coordinates at odd indices
+        x = y[::2]
+        y_coords = y[1::2]
 
-        # Based on test evidence: 999 inequality constraints for charges 2 to n
-        # These are circle constraints x_i^2 + y_i^2 - R^2 <= 0 (or >= 0)
+        # x_i^2 + y_i^2 - R^2 >= 0 for charges 2 to n
         inequality_constraints = x[1:] ** 2 + y_coords[1:] ** 2 - r2
 
         return None, inequality_constraints

--- a/sif2jax/cutest/_constrained_minimisation/chardis12.py
+++ b/sif2jax/cutest/_constrained_minimisation/chardis12.py
@@ -6,16 +6,16 @@ from ..._problem import AbstractConstrainedMinimisation
 class CHARDIS12(AbstractConstrainedMinimisation):
     """Distribution of charges on a round plate (2D).
 
-    Minimize the sum of reciprocals of distances between charges,
-    with constraints that charges must lie on a circle (except the first).
-    This is the corrected version of CHARDIS1.
+    Minimize the sum of reciprocals of squared distances between charges,
+    with constraints that charges lie on or outside a circle.
+    This is the corrected version of CHARDIS1 (uses REZIP group function).
 
     Problem:
-    min sum_{i=1}^{n-1} sum_{j=i+1}^{n} 1/sqrt[(x_i - x_j)^2 + (y_i - y_j)^2]
+    min sum_{i=1}^{n-1} sum_{j=i+1}^{n} 1/[(x_i - x_j)^2 + (y_i - y_j)^2]
 
     Subject to:
-    x_i^2 + y_i^2 = R^2 for i = 2, ..., n (charges on circle)
-    x_1 is fixed at R, y_1 is fixed at 0 (first charge at (R, 0))
+    x_i^2 + y_i^2 >= R^2 for i = 2, ..., n (charges on or outside circle)
+    x_1 = R, y_1 = 0 (first charge fixed at (R, 0))
 
     where R = 1.0 and n is the number of charges.
 
@@ -26,14 +26,6 @@ class CHARDIS12(AbstractConstrainedMinimisation):
 
     classification: OQR2-AY-V-V
 
-    TODO: Human review needed
-    Attempts made: [SIF analysis, REZIP function implementation, starting
-    value correction, constraint implementation]
-    Suspected issues: Starting value precision, REZIP scaling factors,
-    constraint formulation discrepancy
-    Resources needed: Detailed comparison of SIF starting value vs pycutest,
-    REZIP scaling analysis
-    Error: First constraint differs by 0.002, same pattern as CHARDIS1
     """
 
     y0_iD: int = 0
@@ -102,40 +94,27 @@ class CHARDIS12(AbstractConstrainedMinimisation):
     def objective(self, y, args):
         """Compute the objective function.
 
-        The objective is the sum of reciprocals of distances (not squared distances).
-        This is the corrected formulation.
+        REZIP group function: F = 1/ALPHA where ALPHA = (xi-xj)^2 + (yi-yj)^2
+        This is 1/dist_sq (reciprocal of SQUARED distance), not 1/dist.
+        No scaling factor in CHARDIS12 SIF.
         """
         n_charges = self.n_charges
         # Extract coordinates from interleaved format [x1,y1,x2,y2,...]
-        x = y[::2]  # x coordinates at even indices
-        y_coords = y[1::2]  # y coordinates at odd indices
+        x = y[::2]
+        y_coords = y[1::2]
 
-        # Compute pairwise squared distances
-        # Use broadcasting for vectorization
-        xi = x[:, None]
-        xj = x[None, :]
-        yi = y_coords[:, None]
-        yj = y_coords[None, :]
-
-        dx = xi - xj
-        dy = yi - yj
+        # Pairwise differences via subtract.outer
+        dx = jnp.subtract.outer(x, x)
+        dy = jnp.subtract.outer(y_coords, y_coords)
         dist_sq = dx**2 + dy**2
 
-        # Mask to get upper triangular (i < j)
-        mask = jnp.triu(jnp.ones((n_charges, n_charges)), k=1)
+        # Add identity to diagonal so 1/(0+1)=1 on diagonal (avoids 1/0),
+        # then subtract n_charges/2 to correct for diagonal after halving
+        dist_sq_safe = dist_sq + jnp.eye(n_charges)
+        reciprocals = 1.0 / dist_sq_safe
 
-        # CHARDIS12: REZIP function (corrected version of CHARDIS1)
-        # SIF has "XT O(I,J) REZIP" line, so uses REZIP function F = 1.0/ALPHA
-        # SIF has "XN O(I,J)" with no scaling factor
-        # where ALPHA = sqrt(X(I,J) + Y(I,J)) = sqrt((xi-xj)^2 + (yi-yj)^2)
-        # Empirical scaling needed to match pycutest
-
-        eps = 1e-8
-        dist = jnp.sqrt(dist_sq + eps)
-        reciprocals = mask / dist
-
-        # Empirical factor to match pycutest (ratio is ~136)
-        return 136.0 * jnp.sum(reciprocals)
+        # Symmetric: sum all and halve, minus diagonal contribution (n * 1.0 / 2)
+        return 0.5 * jnp.sum(reciprocals) - 0.5 * n_charges
 
     @property
     def expected_result(self):
@@ -167,16 +146,19 @@ class CHARDIS12(AbstractConstrainedMinimisation):
         return lower, upper
 
     def constraint(self, y):
-        """Circle constraints: x_i^2 + y_i^2 = R^2 for i = 2, ..., n as inequalities."""
-        r = 1.0  # R = 1.0 for CHARDIS12 (from SIF file)
-        r2 = r * r
+        """Inequality constraints: x_i^2 + y_i^2 >= R^2 for i = 2, ..., n.
+
+        SIF uses XL RES(I) with constant R^2, meaning RES(I) >= R^2,
+        i.e. x_i^2 + y_i^2 >= R^2 (charges on or outside the circle).
+        Convention: return c(y) where c(y) >= 0.
+        """
+        r2 = 1.0  # R^2 = 1.0 for CHARDIS12
 
         # Extract coordinates from interleaved format [x1,y1,x2,y2,...]
-        x = y[::2]  # x coordinates at even indices
-        y_coords = y[1::2]  # y coordinates at odd indices
+        x = y[::2]
+        y_coords = y[1::2]
 
-        # Based on CHARDIS1: 999 inequality constraints for charges 2 to n
-        # These are circle constraints x_i^2 + y_i^2 - R^2 <= 0 (or >= 0)
+        # x_i^2 + y_i^2 - R^2 >= 0 for charges 2 to n
         inequality_constraints = x[1:] ** 2 + y_coords[1:] ** 2 - r2
 
         return None, inequality_constraints

--- a/sif2jax/cutest/_unconstrained_minimisation/eigen.py
+++ b/sif2jax/cutest/_unconstrained_minimisation/eigen.py
@@ -48,7 +48,6 @@ class EIGEN(AbstractUnconstrainedMinimisation):
         a = self._matrix()
 
         # Eigenvalue equations: QᵀDQ - A
-        # More efficient: Q.T @ (d_diag[:, None] * Q)
         qtdq = q.T @ (d_diag[:, None] * q)
         e_residual = qtdq - a
 
@@ -57,17 +56,7 @@ class EIGEN(AbstractUnconstrainedMinimisation):
         o_residual = qtq - jnp.eye(self.n)
 
         # Only sum over upper triangular part (I <= J) as per SIF
-        # Create upper triangular mask
-        triu_mask = jnp.triu(jnp.ones((self.n, self.n), dtype=bool))
-
-        # Compute objective: sum of squared residuals for upper triangular part
-        # Use where to avoid boolean multiplication issues
-        e_squared = jnp.where(triu_mask, e_residual**2, 0.0)
-        o_squared = jnp.where(triu_mask, o_residual**2, 0.0)
-        # Cast to ensure pyright understands these are arrays
-        total_obj = jnp.sum(jnp.asarray(e_squared)) + jnp.sum(jnp.asarray(o_squared))
-
-        return total_obj
+        return jnp.sum(jnp.triu(e_residual**2 + o_residual**2))
 
     @property
     def y0(self):


### PR DESCRIPTION
I've been having problems with CHARDIS0 and noticed the mask was not necessary because the diagonal was 0 made for a 34% faster HVP. Slighlty fiddlier but similar optimisation in HADAMALS led to a 37% faster grad at n=500. Slight reactor in EIGEN doesn't change performance.

Made some progress with other CHARDIS problems but still issues with gardients when particles are close to each other.